### PR TITLE
collections.Iterable no longer works in python 3.9 and newer

### DIFF
--- a/src/voeventparse/voevent.py
+++ b/src/voeventparse/voevent.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import copy
-import collections
+from typing import Iterable
 
 import pytz
 from lxml import objectify, etree
@@ -431,7 +431,7 @@ def _listify(x):
     """Ensure x is iterable; if not then enclose it in a list and return it."""
     if isinstance(x, string_types):
         return [x]
-    elif isinstance(x, collections.Iterable):
+    elif isinstance(x, Iterable):
         return x
     else:
         return [x]


### PR DESCRIPTION
Here is a trivial PR to address the following warning (and no longer works in python >=  3.9):

DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working.

I've elected to import Iterable from typing, but this is considered deprecated and may stop working at 3.9 EOL in 2025. [see https://peps.python.org/pep-0585/] This PR could also be implemented by simply importing Iterable from collections.abc.